### PR TITLE
Add cryptographic utilities for password handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS
+
+- Use Python 3.11+ with type hints and PEP 8 style.
+- Avoid exposing secrets; load sensitive data from environment variables.
+- Run `pytest` before committing any changes.
+- Keep dependencies minimal and specify them in `requirements.txt`.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # bitsafe-utils
+
 Building a system to motivate users into knowing, using and holding our token.
+
+## Crypto Service
+
+`bitsafe_utils.crypto_service` provides helpers to decrypt a password with an
+RSA private key and re-encrypt it using an application secret before sending it
+to the Bitsafe backend. This keeps the application secret outside of the
+frontend while ensuring the backend never sees the password in plaintext.
+
+### Development
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+### Testing
+
+```bash
+pytest
+```

--- a/bitsafe_utils/__init__.py
+++ b/bitsafe_utils/__init__.py
@@ -1,0 +1,3 @@
+"""Utility modules for Bitsafe projects."""
+
+__all__ = ["crypto_service"]

--- a/bitsafe_utils/crypto_service.py
+++ b/bitsafe_utils/crypto_service.py
@@ -1,0 +1,82 @@
+"""Cryptographic helpers for secure password handling.
+
+This module enables a client to encrypt a password with an RSA public key
+and a wrapper service to decrypt that payload and re-encrypt it using an
+application secret before forwarding it to the Bitsafe backend.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+
+def encrypt_with_public_key(password: str, public_key_pem: bytes) -> str:
+    """Encrypt ``password`` using the given RSA ``public_key_pem``.
+
+    Returns:
+        Base64 encoded ciphertext ready to be sent to the wrapper service.
+    """
+    public_key = serialization.load_pem_public_key(public_key_pem)
+    ciphertext = public_key.encrypt(
+        password.encode("utf-8"),
+        padding.OAEP(
+            mgf=padding.MGF1(algorithm=hashes.SHA256()),
+            algorithm=hashes.SHA256(),
+            label=None,
+        ),
+    )
+    return base64.b64encode(ciphertext).decode("utf-8")
+
+
+def decrypt_with_private_key(encrypted_b64: str, private_key_pem: bytes) -> str:
+    """Decrypt base64 ``encrypted_b64`` using the RSA ``private_key_pem``."""
+    private_key = serialization.load_pem_private_key(private_key_pem, password=None)
+    encrypted = base64.b64decode(encrypted_b64)
+    plaintext = private_key.decrypt(
+        encrypted,
+        padding.OAEP(
+            mgf=padding.MGF1(algorithm=hashes.SHA256()),
+            algorithm=hashes.SHA256(),
+            label=None,
+        ),
+    )
+    return plaintext.decode("utf-8")
+
+
+def _derive_aes_key(app_secret: str) -> bytes:
+    """Derive a 256-bit AES key from ``app_secret`` using SHA-256."""
+    return hashlib.sha256(app_secret.encode("utf-8")).digest()
+
+
+def encrypt_with_app_secret(password: str, app_secret: str) -> str:
+    """Encrypt ``password`` using ``app_secret`` with AES-GCM.
+
+    Returns a base64 encoded string containing IV and ciphertext.
+    """
+    key = _derive_aes_key(app_secret)
+    aesgcm = AESGCM(key)
+    iv = os.urandom(12)  # AESGCM standard nonce size
+    ciphertext = aesgcm.encrypt(iv, password.encode("utf-8"), None)
+    return base64.b64encode(iv + ciphertext).decode("utf-8")
+
+
+def decrypt_with_app_secret(encrypted_b64: str, app_secret: str) -> str:
+    """Decrypt payload produced by :func:`encrypt_with_app_secret`."""
+    key = _derive_aes_key(app_secret)
+    aesgcm = AESGCM(key)
+    data = base64.b64decode(encrypted_b64)
+    iv, ciphertext = data[:12], data[12:]
+    plaintext = aesgcm.decrypt(iv, ciphertext, None)
+    return plaintext.decode("utf-8")
+
+
+def process_password(encrypted_b64: str, private_key_pem: bytes, app_secret: str) -> str:
+    """Decrypt RSA-encrypted payload and re-encrypt with ``app_secret``."""
+    plaintext = decrypt_with_private_key(encrypted_b64, private_key_pem)
+    return encrypt_with_app_secret(plaintext, app_secret)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+cryptography>=41.0.0
+pytest>=7.0.0

--- a/tests/test_crypto_service.py
+++ b/tests/test_crypto_service.py
@@ -1,0 +1,33 @@
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from bitsafe_utils.crypto_service import (
+    decrypt_with_app_secret,
+    encrypt_with_public_key,
+    process_password,
+)
+
+
+def generate_keys():
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_pem, public_pem
+
+
+def test_process_password_round_trip():
+    private_pem, public_pem = generate_keys()
+    password = "Tr0ub4dor&3"
+    app_secret = "super-secret-key"
+
+    encrypted_for_wrapper = encrypt_with_public_key(password, public_pem)
+    re_encrypted = process_password(encrypted_for_wrapper, private_pem, app_secret)
+    decrypted = decrypt_with_app_secret(re_encrypted, app_secret)
+    assert decrypted == password


### PR DESCRIPTION
## Summary
- add cryptographic helpers for password encryption and re-encryption using RSA and AES-GCM
- document development workflow and guidelines
- include unit test for round-trip password processing

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement cryptography>=41.0.0)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'cryptography')*


------
https://chatgpt.com/codex/tasks/task_e_689ac3e42d74832da0a7a32f386b7a64