### PR TITLE
Ensure Flask re-encrypt endpoint is testable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,5 +5,7 @@
 - Run `pytest` before committing any changes.
 - Keep dependencies minimal and specify them in `requirements.txt`.
 - API endpoints live in `bitsafe_utils.app` and use FastAPI.
+- `server.py` exposes Flask endpoints and should instantiate a new
+  `BitsafeMiddleware` when `app.config['TESTING']` is true so tests can mock it.
 - Store the RSA private key as `PRIVATE_KEY` and the Fernet key as `APP_SECRET`.
 - Key generation utilities live in `scripts/generate_keys.py`; do not add duplicate key generation scripts elsewhere.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ writes the private key with `600` permissions so it isn't world readable:
 python scripts/generate_keys.py --private ./private_key.pem --public ./public_key.pem
 ```
 
+## Flask Middleware Server
+
+`server.py` provides a Flask implementation suitable for multi-application
+deployments. Each request can instantiate a fresh
+`BitsafeMiddleware` when `app.config['TESTING']` is enabled, allowing the
+middleware to be easily mocked in unit tests.
+
+Run the server with:
+
+```bash
+python server.py
+```
+
 ### Development
 
 Install dependencies:

--- a/bitsafe_utils/middleware_service.py
+++ b/bitsafe_utils/middleware_service.py
@@ -43,6 +43,24 @@ class BitsafeMiddleware:
         )
         logger.info(f"Registered app: {app_id}")
 
+    def process_password(
+        self,
+        encrypted_password: str,
+        private_key_pem: bytes,
+        app_secret: str,
+    ) -> str:
+        """Decrypt and re-encrypt ``encrypted_password`` for backend use.
+
+        Args:
+            encrypted_password: Password encrypted with the public key.
+            private_key_pem: RSA private key in PEM format.
+            app_secret: Secret used to encrypt the password for the backend.
+
+        Returns:
+            The password re-encrypted with ``app_secret``.
+        """
+        return process_password(encrypted_password, private_key_pem, app_secret)
+
     def _get_app_config(self, app_id: str) -> AppConfig:
         """Get app configuration or raise error if not found."""
         if app_id not in self.apps:
@@ -85,10 +103,10 @@ class BitsafeMiddleware:
         app_config = self._get_app_config(app_id)
 
         # Decrypt and re-encrypt password with app secret
-        password_for_backend = process_password(
+        password_for_backend = self.process_password(
             encrypted_password,
             app_config.public_key,
-            app_config.app_secret
+            app_config.app_secret,
         )
 
         payload = {
@@ -116,10 +134,10 @@ class BitsafeMiddleware:
         app_config = self._get_app_config(app_id)
 
         # Decrypt and re-encrypt password with app secret
-        password_for_backend = process_password(
+        password_for_backend = self.process_password(
             encrypted_password,
             app_config.public_key,
-            app_config.app_secret
+            app_config.app_secret,
         )
 
         payload = {


### PR DESCRIPTION
## Summary
- allow Flask re-encrypt route to create a mockable BitsafeMiddleware in tests
- add process_password helper to BitsafeMiddleware and use it consistently
- document Flask server and testing hook

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ed2561134832da8ed44f10f8f666a