### PR TITLE
test: verify app id not registered error message

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,4 +13,6 @@
   `APP_i_ID`, `APP_i_SECRET`, `APP_i_PRIVATE_KEY_PATH`, and
   `APP_i_PUBLIC_KEY_PATH`.
 - Store the RSA private key as `PRIVATE_KEY` and the Fernet key as `APP_SECRET`.
+- Return descriptive error messages; missing apps must yield
+  `"App ID {app_id} not registered"`.
 - Key generation utilities live in `scripts/generate_keys.py`; do not add duplicate key generation scripts elsewhere.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Each application is configured through environment variables. For an index
 - `APP_i_PUBLIC_KEY_PATH`: Path to the corresponding RSA public key served to
   clients.
 
+If a client requests an unregistered application, the middleware responds with a
+`404` status and a JSON body of the form
+`{"error": "App ID <app_id> not registered"}`.
+
 Run the server with:
 
 ```bash

--- a/tests/test_re_encrypt_endpoint.py
+++ b/tests/test_re_encrypt_endpoint.py
@@ -85,21 +85,18 @@ koQYxAHw1JXmSRgGg7hSuMhvqwVA6+sAkNtKpmoaFa7j2d33EgI=
 
     def test_re_encrypt_password_app_not_found(self):
         """Test error when app ID is not registered."""
+        app_id = "nonexistent_app"
         with patch('bitsafe_utils.middleware_service.BitsafeMiddleware') as mock_middleware_class:
             mock_middleware = mock_middleware_class.return_value
-            mock_app_config = MagicMock()
-            mock_app_config.app_secret = "test_secret"
-            mock_app_config.private_key = b"test_private_key"
-
             mock_middleware._get_app_config.side_effect = ValueError(
-                "App not found")
+                f"App ID {app_id} not registered")
 
             payload = {
                 'encryptedPassword': 'encrypted_password_from_frontend'
             }
 
             response = self.app.post(
-                '/apps/nonexistent_app/re-encrypt-password',
+                f'/apps/{app_id}/re-encrypt-password',
                 data=json.dumps(payload),
                 content_type='application/json'
             )
@@ -107,6 +104,7 @@ koQYxAHw1JXmSRgGg7hSuMhvqwVA6+sAkNtKpmoaFa7j2d33EgI=
             self.assertEqual(response.status_code, 404)
             data = json.loads(response.data)
             self.assertIn('error', data)
+            self.assertEqual(data['error'], f"App ID {app_id} not registered")
 
     def test_re_encrypt_password_empty_payload(self):
         """Test error when payload is empty."""


### PR DESCRIPTION
## Summary
- ensure re-encrypt endpoint test checks `App ID {app_id} not registered` message
- document expected 404 response for unknown app IDs
- clarify AGENTS instructions about descriptive error messages

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a553651fe8832db61837926da9c115