### PR TITLE
Load environment variables from .env

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 - Use Python 3.11+ with type hints and PEP 8 style.
 - Avoid exposing secrets; load sensitive data from environment variables.
+- Environment variables may be loaded from a `.env` file using `python-dotenv`;
+  call `load_dotenv()` before accessing them.
 - Run `PYTHONPATH=. pytest` before committing any changes.
 - Keep dependencies minimal and specify them in `requirements.txt`.
 - API endpoints live in `bitsafe_utils.app` and use FastAPI.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ python server.py  # uses Waitress in production
 
 Set `DEBUG=true` to use Flask's development server during local development.
 
+### Environment Configuration
+
+Both the FastAPI and Flask applications load environment variables from a `.env`
+file using [`python-dotenv`](https://pypi.org/project/python-dotenv/). Copy
+`.env.example` to `.env` and populate it with the required values for local
+development. Never commit real secrets to source control.
+
 ### Development
 
 Install dependencies:

--- a/bitsafe_utils/app.py
+++ b/bitsafe_utils/app.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import os
 
+from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
 from .crypto_service import process_password
+
+load_dotenv()
 
 app = FastAPI()
 

--- a/server.py
+++ b/server.py
@@ -8,7 +8,10 @@ to interact with the Bitsafe backend without exposing app-secrets.
 
 import os
 from flask import Flask, request, jsonify
+from dotenv import load_dotenv
 import bitsafe_utils.middleware_service as middleware_service
+
+load_dotenv()
 
 # Initialize Flask app
 app = Flask(__name__)


### PR DESCRIPTION
## Summary
- load environment variables from a `.env` file in both the Flask and FastAPI applications
- document `.env` usage and note python-dotenv in AGENTS guidelines

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a55367a4e4832da7b06036cf752c86