### PR TITLE
Use FastAPI lifespan events for initialization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - Keep dependencies minimal and specify them in `requirements.txt`.
 - Use `requests` for HTTP client interactions; avoid adding `httpx` unless necessary.
 - API endpoints live in `bitsafe_utils.app` and use FastAPI.
+- Initialize FastAPI apps with lifespan events instead of `@app.on_event`.
 - Per-application configuration is loaded from environment variables
   `APP_i_ID`, `APP_i_SECRET`, `APP_i_PRIVATE_KEY_PATH`, and
   `APP_i_PUBLIC_KEY_PATH`.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ password in plaintext.
 
 `bitsafe_utils.app` exposes a FastAPI application with endpoints for password
 re-encryption and proxying authentication requests to the Bitsafe backend. The
-`/re-encrypt` endpoint accepts an RSA-encrypted password and returns it
+application loads configured apps during startup using FastAPI lifespan events.
+The `/re-encrypt` endpoint accepts an RSA-encrypted password and returns it
 encrypted with the app secret. The endpoint expects the following environment
 variables:
 

--- a/bitsafe_utils/app.py
+++ b/bitsafe_utils/app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+from contextlib import asynccontextmanager
 from typing import Optional
 
 from fastapi import FastAPI, HTTPException
@@ -13,8 +14,6 @@ from . import middleware_service
 from .crypto_service import process_password
 
 logger = logging.getLogger(__name__)
-
-app = FastAPI()
 
 
 # ---------------------------------------------------------------------------
@@ -49,9 +48,14 @@ def load_apps_from_env() -> list[str]:
     return app_configs
 
 
-@app.on_event("startup")
-def startup() -> None:  # pragma: no cover - FastAPI startup
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Load apps at startup using FastAPI's lifespan events."""
     load_apps_from_env()
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- replace deprecated `@app.on_event` with a FastAPI lifespan handler to load app configs at startup
- document lifespan usage in README and AGENTS guidelines

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5608b540c832dbe05c7f1ca550147